### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/LICENSE
+++ b/LICENSE
@@ -534,7 +534,7 @@ For vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor:
 Extensions for Protocol Buffers to create more go like structures.
 
 Copyright (c) 2013, Vastech SA (PTY) LTD. All rights reserved.
-http://github.com/gogo/protobuf/gogoproto
+https://github.com/gogo/protobuf/gogoproto
 
 Go support for Protocol Buffers - Google's data interchange format
 
@@ -573,7 +573,7 @@ For vendor/github.com/gogo/protobuf/gogoproto:
 Protocol Buffers for Go with Gadgets
 
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
-http://github.com/gogo/protobuf
+https://github.com/gogo/protobuf
 
 Go support for Protocol Buffers - Google's data interchange format
 
@@ -612,7 +612,7 @@ For vendor/github.com/gogo/protobuf/proto:
 Protocol Buffers for Go with Gadgets
 
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
-http://github.com/gogo/protobuf
+https://github.com/gogo/protobuf
 
 Go support for Protocol Buffers - Google's data interchange format
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://github.com/gogo/protobuf/gogoproto (301) with 1 occurrences migrated to:  
  https://github.com/gogo/protobuf/gogoproto ([https](https://github.com/gogo/protobuf/gogoproto) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://github.com/gogo/protobuf with 2 occurrences migrated to:  
  https://github.com/gogo/protobuf ([https](https://github.com/gogo/protobuf) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).